### PR TITLE
Update/Redraw Dialog when progressing

### DIFF
--- a/Progressor.jsxinc
+++ b/Progressor.jsxinc
@@ -55,6 +55,7 @@ var Progressor = function(names){
     progress: function(i,of) {
       dlg.progressbar.value=Math.round(100*i/of);
       dlg.stautsText.text=_(msg.progress,i+1,of);
+      dlg.update();
     },
     // Call at the end of the script
     done: function() {


### PR DESCRIPTION
Had to use 'dlg.update()' for the progressor to redraw.
Not sure if this has something to do with the newer PS-2021 version